### PR TITLE
Add checking PHP version to PHP float bug fix

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -16,7 +16,7 @@
  * @package modx
  */
 /* fix for PHP float bug: http://bugs.php.net/bug.php?id=53632 (php 4 <= 4.4.9 and php 5 <= 5.3.4) */
-if (strstr(str_replace('.','',serialize(array_merge($_GET, $_POST, $_COOKIE))), '22250738585072011')) {
+if (strstr(str_replace('.','',serialize(array_merge($_GET, $_POST, $_COOKIE))), '22250738585072011') && (@version_compare(PHP_VERSION, '4.4.9', '<=')  || (@version_compare(PHP_VERSION, '5.0.0', '>') && @version_compare(PHP_VERSION, '5.3.4', '<=')))) {
     header('Status: 422 Unprocessable Entity');
     die();
 }


### PR DESCRIPTION
### What does it do?

Add checking PHP version according to comment in line:18. @ sign is added to suppresses error messages with PHP < 4.1.0 (which don't have "version_compare" functions implemented).
### Why is it needed?

To prevent 422 response when sending '22250738585072011' string  (this string may be part of serial number, API key or part of any larger string/text) on servers with right versions of PHP.
### Related issue(s)/PR(s)

none
